### PR TITLE
feat: Create Notion Integrated Search Application

### DIFF
--- a/notion_search_app/.gitignore
+++ b/notion_search_app/.gitignore
@@ -1,0 +1,11 @@
+# Environment variables
+.env
+
+# Python cache
+__pycache__/
+*.pyc
+*.pyo
+
+# IDE settings
+.vscode/
+.idea/

--- a/notion_search_app/app.py
+++ b/notion_search_app/app.py
@@ -1,0 +1,198 @@
+import os
+import json
+import notion_client
+import serpapi
+from openai import OpenAI
+from flask import Flask, request, jsonify, render_template
+from dotenv import load_dotenv
+
+# .envファイルから環境変数を読み込む
+load_dotenv()
+
+# --- 環境変数から設定を読み込み ---
+NOTION_API_KEY = os.getenv("NOTION_API_KEY")
+NOTION_DATABASE_ID = os.getenv("NOTION_DATABASE_ID")
+OPENAI_API_KEY = os.getenv("OPENAI_API_KEY") # 今後のステップで使用
+
+# --- FlaskアプリケーションとNotionクライアントの初期化 ---
+app = Flask(__name__)
+notion = notion_client.Client(auth=NOTION_API_KEY)
+openai_client = OpenAI(api_key=OPENAI_API_KEY)
+
+
+def add_page_to_notion(title, content, url, query, category):
+    """
+    指定された内容でNotionデータベースに新しいページを追加する。
+    """
+    if not all([NOTION_API_KEY, NOTION_DATABASE_ID]):
+        print("エラー: NotionのAPIキーまたはデータベースIDが設定されていません。")
+        return None
+
+    try:
+        new_page = {
+            "Title": {"title": [{"text": {"content": title}}]},
+            "URL": {"url": url},
+            "Content": {"rich_text": [{"text": {"content": content}}]},
+            "Query": {"rich_text": [{"text": {"content": query}}]},
+            "Category": {"multi_select": [{"name": category}]},
+        }
+
+        response = notion.pages.create(
+            parent={"database_id": NOTION_DATABASE_ID},
+            properties=new_page
+        )
+        print("Notionにページが正常に追加されました。")
+        return response
+    except Exception as e:
+        print(f"Notionへのページ追加中にエラーが発生しました: {e}")
+        return None
+
+@app.route('/')
+def index():
+    """
+    フロントエンドのHTMLページを返す
+    """
+    return render_template('index.html')
+
+
+# --- 検索・AI関連の関数 ---
+
+# AIが分類を選ぶためのカテゴリリスト
+CATEGORIES = ["仕事", "プログラミング", "趣味", "学習", "ニュース", "生活ハック", "その他"]
+
+def search_with_google(query):
+    """
+    SerpApiを使用してGoogle検索を実行し、最初のオーガニック検索結果のスニペットとリンクを返す。
+    """
+    serpapi_key = os.getenv("SERPAPI_API_KEY")
+    if not serpapi_key:
+        return {"error": "SerpApiのAPIキーが設定されていません。"}, None
+
+    params = {
+        "q": query,
+        "api_key": serpapi_key,
+        "engine": "google",
+        "hl": "ja",
+        "gl": "jp",
+    }
+    search = serpapi.GoogleSearch(params)
+    results = search.get_dict()
+
+    if "organic_results" in results and results["organic_results"]:
+        first_result = results["organic_results"][0]
+        return first_result.get("snippet", "スニペットが見つかりません。"), first_result.get("link")
+    return "検索結果が見つかりませんでした。", None
+
+def search_with_chatgpt(query):
+    """
+    OpenAI APIを使用してChatGPTに質問し、回答を返す。
+    """
+    if not OPENAI_API_KEY:
+        return {"error": "OpenAIのAPIキーが設定されていません。"}, None
+
+    try:
+        completion = openai_client.chat.completions.create(
+            model="gpt-3.5-turbo",
+            messages=[
+                {"role": "system", "content": "あなたは優秀なアシスタントです。簡潔に、しかし分かりやすく回答してください。"},
+                {"role": "user", "content": query}
+            ]
+        )
+        content = completion.choices[0].message.content
+        return content, "ChatGPT"
+    except Exception as e:
+        return f"ChatGPTからの回答取得中にエラー: {e}", "ChatGPT"
+
+def get_category_suggestions(text):
+    """
+    与えられたテキストの内容を解釈し、定義済みのカテゴリリストから最も関連性の高いものを3つ提案する。
+    """
+    if not OPENAI_API_KEY:
+        return ["エラー: OpenAIキー未設定"]
+
+    prompt = f"""
+    以下のテキスト内容を分析し、最も関連性が高いと思われるカテゴリを下記のリストから最大3つ選んでください。
+    回答はカテゴリ名のリスト（例: ["カテゴリ1", "カテゴリ2"]）の形式で、JSON配列としてのみ返してください。他の言葉は一切含めないでください。
+
+    ---
+    テキスト内容:
+    "{text}"
+    ---
+    カテゴリリスト:
+    {CATEGORIES}
+    ---
+    """
+    try:
+        completion = openai_client.chat.completions.create(
+            model="gpt-3.5-turbo",
+            messages=[
+                {"role": "system", "content": "あなたはテキストを分類する専門家です。"},
+                {"role": "user", "content": prompt}
+            ],
+            temperature=0.2,
+        )
+        response_text = completion.choices[0].message.content
+        # AIの回答からJSONリストを抽出する
+        suggested_categories = json.loads(response_text)
+        return suggested_categories
+    except Exception as e:
+        print(f"カテゴリ分類中にエラー: {e}")
+        # エラー時はデフォルトのカテゴリ候補を返す
+        return ["仕事", "学習", "その他"]
+
+# --- APIエンドポイント ---
+
+@app.route("/api/save", methods=['POST'])
+def api_save():
+    """
+    フロントエンドからデータを受け取り、Notionにページを追加する。
+    """
+    data = request.get_json()
+    response = add_page_to_notion(
+        title=data.get('title'),
+        content=data.get('content'),
+        url=data.get('url'),
+        query=data.get('query'),
+        category=data.get('category')
+    )
+    if response:
+        return jsonify({"success": True, "page_id": response.get("id")})
+    else:
+        return jsonify({"success": False, "error": "Failed to save to Notion"}), 500
+
+@app.route("/api/search", methods=['POST'])
+def api_search():
+    data = request.get_json()
+    query = data.get('query')
+    engine = data.get('engine')
+
+    if not query or not engine:
+        return jsonify({"error": "クエリとエンジンが必要です"}), 400
+
+    content, source_url = "", ""
+    if engine == 'google':
+        content, source_url = search_with_google(query)
+    elif engine == 'chatgpt':
+        content, source_url = search_with_chatgpt(query)
+    else:
+        return jsonify({"error": "無効な検索エンジンです"}), 400
+
+    if isinstance(content, dict) and "error" in content: # APIキーエラーなどをハンドリング
+        return jsonify(content), 500
+
+    suggestions = get_category_suggestions(f"クエリ: {query}\n内容: {content}")
+
+    return jsonify({
+        "content": content,
+        "source_url": source_url,
+        "suggestions": suggestions
+    })
+
+
+# --- メインの実行ブロック ---
+if __name__ == '__main__':
+    # サーバーを起動する前に、必要な環境変数が設定されているか確認
+    if not all([NOTION_API_KEY, NOTION_DATABASE_ID]):
+        print("警告: NOTION_API_KEY と NOTION_DATABASE_ID の両方を.envファイルに設定してください。")
+
+    app.run(debug=True, port=5001)

--- a/notion_search_app/requirements.txt
+++ b/notion_search_app/requirements.txt
@@ -1,0 +1,6 @@
+flask
+python-dotenv
+requests
+notion-client
+openai
+google-search-results

--- a/notion_search_app/static/script.js
+++ b/notion_search_app/static/script.js
@@ -1,0 +1,128 @@
+document.addEventListener('DOMContentLoaded', () => {
+    const searchInput = document.getElementById('search-input');
+    const searchBtn = document.getElementById('search-btn');
+    const engineBtns = document.querySelectorAll('.engine-btn');
+    const loadingDiv = document.getElementById('loading');
+    const resultsArea = document.getElementById('results-area');
+    const resultContent = document.getElementById('result-content');
+    const resultSource = document.getElementById('result-source');
+    const categoryButtonsDiv = document.getElementById('category-buttons');
+    const saveConfirmationDiv = document.getElementById('save-confirmation');
+
+    let selectedEngine = 'google';
+    let currentSearchResult = {};
+
+    // --- Event Listeners ---
+
+    // Search engine selection
+    engineBtns.forEach(btn => {
+        btn.addEventListener('click', () => {
+            engineBtns.forEach(b => b.classList.remove('active'));
+            btn.classList.add('active');
+            selectedEngine = btn.dataset.engine;
+        });
+    });
+
+    // Search button click
+    searchBtn.addEventListener('click', handleSearch);
+    searchInput.addEventListener('keyup', (event) => {
+        if (event.key === 'Enter') {
+            handleSearch();
+        }
+    });
+
+    // --- Functions ---
+
+    async function handleSearch() {
+        const query = searchInput.value.trim();
+        if (!query) {
+            alert('検索キーワードを入力してください。');
+            return;
+        }
+
+        // Reset UI
+        resultsArea.classList.add('hidden');
+        saveConfirmationDiv.classList.add('hidden');
+        loadingDiv.classList.remove('hidden');
+
+        try {
+            const response = await fetch('/api/search', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ query, engine: selectedEngine }),
+            });
+
+            if (!response.ok) {
+                throw new Error(`サーバーエラー: ${response.statusText}`);
+            }
+
+            const data = await response.json();
+            currentSearchResult = { ...data, query };
+            displayResults(data);
+
+        } catch (error) {
+            resultContent.textContent = `エラーが発生しました: ${error.message}`;
+        } finally {
+            loadingDiv.classList.add('hidden');
+            resultsArea.classList.remove('hidden');
+        }
+    }
+
+    function displayResults(data) {
+        resultContent.textContent = data.content;
+        resultSource.textContent = data.source_url;
+        resultSource.href = data.source_url;
+
+        categoryButtonsDiv.innerHTML = ''; // Clear old buttons
+        data.suggestions.forEach(category => {
+            const button = document.createElement('button');
+            button.textContent = category;
+            button.dataset.category = category;
+            button.addEventListener('click', () => handleSave(category));
+            categoryButtonsDiv.appendChild(button);
+        });
+    }
+
+    async function handleSave(category) {
+        // Highlight selected category button
+        document.querySelectorAll('#category-buttons button').forEach(btn => {
+            btn.classList.remove('selected');
+        });
+        document.querySelector(`#category-buttons button[data-category="${category}"]`).classList.add('selected');
+
+        const saveData = {
+            title: currentSearchResult.query,
+            content: currentSearchResult.content,
+            url: currentSearchResult.source_url,
+            query: currentSearchResult.query,
+            category: category,
+        };
+
+        try {
+            const response = await fetch('/api/save', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify(saveData),
+            });
+            const result = await response.json();
+
+            if (result.success) {
+                showSaveConfirmation(true, `Notionに保存しました！ (Page ID: ${result.page_id})`);
+            } else {
+                throw new Error(result.error || '不明なエラー');
+            }
+        } catch (error) {
+            showSaveConfirmation(false, `保存に失敗しました: ${error.message}`);
+        }
+    }
+
+    function showSaveConfirmation(isSuccess, message) {
+        saveConfirmationDiv.className = isSuccess ? 'success' : 'error';
+        saveConfirmationDiv.textContent = message;
+        saveConfirmationDiv.classList.remove('hidden');
+
+        setTimeout(() => {
+            saveConfirmationDiv.classList.add('hidden');
+        }, 5000);
+    }
+});

--- a/notion_search_app/static/style.css
+++ b/notion_search_app/static/style.css
@@ -1,0 +1,156 @@
+@import url('https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@400;700&display=swap');
+
+body {
+    font-family: 'Noto Sans JP', sans-serif;
+    background-color: #f4f4f9;
+    color: #333;
+    margin: 0;
+    padding: 20px;
+    display: flex;
+    justify-content: center;
+    align-items: flex-start;
+    min-height: 100vh;
+}
+
+.container {
+    width: 100%;
+    max-width: 800px;
+    background: #fff;
+    padding: 30px;
+    border-radius: 8px;
+    box-shadow: 0 4px 15px rgba(0, 0, 0, 0.1);
+}
+
+h1 {
+    text-align: center;
+    color: #4a4a4a;
+    margin-bottom: 30px;
+}
+
+.search-box {
+    display: flex;
+    gap: 10px;
+    margin-bottom: 20px;
+    flex-wrap: wrap;
+}
+
+#search-input {
+    flex-grow: 1;
+    padding: 12px;
+    border: 1px solid #ddd;
+    border-radius: 4px;
+    font-size: 16px;
+    min-width: 200px;
+}
+
+.engine-selector {
+    display: flex;
+}
+
+.engine-btn {
+    padding: 12px 15px;
+    border: 1px solid #ddd;
+    background-color: #f8f8f8;
+    cursor: pointer;
+    font-size: 16px;
+    transition: background-color 0.3s, color 0.3s;
+}
+.engine-btn:first-of-type {
+    border-radius: 4px 0 0 4px;
+    border-right: none;
+}
+.engine-btn:last-of-type {
+    border-radius: 0 4px 4px 0;
+}
+.engine-btn.active {
+    background-color: #007bff;
+    color: white;
+    border-color: #007bff;
+}
+
+#search-btn {
+    padding: 12px 20px;
+    background-color: #28a745;
+    color: white;
+    border: none;
+    border-radius: 4px;
+    cursor: pointer;
+    font-size: 16px;
+    font-weight: bold;
+    transition: background-color 0.3s;
+}
+
+#search-btn:hover {
+    background-color: #218838;
+}
+
+#loading {
+    text-align: center;
+    padding: 20px;
+    font-size: 18px;
+    color: #666;
+}
+
+#results-area {
+    margin-top: 30px;
+    border-top: 1px solid #eee;
+    padding-top: 20px;
+}
+
+#result-content {
+    background-color: #f9f9f9;
+    border: 1px solid #eee;
+    padding: 15px;
+    border-radius: 4px;
+    line-height: 1.6;
+    white-space: pre-wrap;
+    word-wrap: break-word;
+}
+
+#category-selector {
+    margin-top: 20px;
+}
+
+#category-buttons button {
+    margin-right: 10px;
+    margin-bottom: 10px;
+    padding: 8px 15px;
+    border: 1px solid #007bff;
+    border-radius: 20px;
+    background-color: #fff;
+    color: #007bff;
+    cursor: pointer;
+    transition: background-color 0.3s, color 0.3s;
+}
+
+#category-buttons button:hover {
+    background-color: #e6f2ff;
+}
+
+#category-buttons button.selected {
+    background-color: #007bff;
+    color: white;
+}
+
+
+#save-confirmation {
+    margin-top: 15px;
+    padding: 12px;
+    border-radius: 4px;
+    text-align: center;
+}
+#save-confirmation.success {
+    background-color: #d4edda;
+    color: #155724;
+    border: 1px solid #c3e6cb;
+}
+#save-confirmation.error {
+    background-color: #f8d7da;
+    color: #721c24;
+    border: 1px solid #f5c6cb;
+}
+
+
+.hidden {
+    display: none;
+}

--- a/notion_search_app/templates/index.html
+++ b/notion_search_app/templates/index.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Notion統合検索</title>
+    <link rel="stylesheet" href="/static/style.css">
+</head>
+<body>
+    <div class="container">
+        <h1>Notion統合検索</h1>
+        <div class="search-box">
+            <input type="text" id="search-input" placeholder="検索キーワードを入力...">
+            <div class="engine-selector">
+                <button class="engine-btn active" data-engine="google">Google</button>
+                <button class="engine-btn" data-engine="chatgpt">ChatGPT</button>
+            </div>
+            <button id="search-btn">検索</button>
+        </div>
+
+        <div id="loading" class="hidden">検索中...</div>
+
+        <div id="results-area" class="hidden">
+            <h2>検索結果</h2>
+            <div id="result-content"></div>
+            <p><strong>ソース:</strong> <a id="result-source" href="#" target="_blank"></a></p>
+
+            <div id="category-selector">
+                <h3>カテゴリを選択して保存</h3>
+                <div id="category-buttons"></div>
+            </div>
+
+            <div id="save-confirmation" class="hidden"></div>
+        </div>
+    </div>
+    <script src="/static/script.js"></script>
+</body>
+</html>


### PR DESCRIPTION
This commit introduces a new Flask-based web application that allows users to search Google or ChatGPT and save the results to a Notion database.

Key Features:
- Web interface for entering search queries and selecting a search engine (Google/ChatGPT).
- Backend API to handle search requests and orchestrate API calls.
- Integration with SerpApi for Google search results.
- Integration with OpenAI API for ChatGPT responses and AI-powered category suggestions.
- Functionality to save the search query, result, source URL, and a user-selected category to a specified Notion database.
- The application is self-contained within the `notion_search_app` directory, including all dependencies and frontend assets.